### PR TITLE
FIX to make plugin work with Sketch 3.3

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -28,7 +28,6 @@ function createGroup(config) {
 
 function createRectangle(config) {
   var rectangle = config.parent.addLayerOfType('rectangle');
-  rectangle = rectangle.embedInShapeGroup();
   rectangle.setName(config.name);
   rectangle.frame().x = config.x;
   rectangle.frame().y = config.y;


### PR DESCRIPTION
embedInShapeGroup was removed in Sketch 3.3. Plugin fails when it reaches that line.

Seems to work fine without using the _shapeWithPath_ function suggested in the link below.  

For more info, see here:
http://mail.sketchplugins.com/pipermail/dev_sketchplugins.com/2014-December/001033.html
